### PR TITLE
feature/#9-prisma extend 구현

### DIFF
--- a/src/xprisma.js
+++ b/src/xprisma.js
@@ -1,0 +1,49 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+function normalizeIdFilter(prev) {
+  if (prev && typeof prev === "object") return prev;
+  if (prev !== undefined) return { equals: prev };
+  return {};
+}
+
+async function applyBlockFilter(args) {
+  const blockerUserId = args?.where?.blockerId;
+  if (blockerUserId == null) return;
+
+  const prevAuthorId = args.where?.authorId;
+
+  delete args.where.blockerId;
+
+  const blockedUserIds = await prisma.block.findMany({
+    where: { blockerId: blockerUserId },
+    select: { blockedId: true },
+  });
+
+  const blockedIds = blockedUserIds.map((b) => b.blockedId);
+  if (blockedIds.length === 0) return;
+
+  args.where = {
+    ...args.where,
+    authorId: {
+      ...normalizeIdFilter(prevAuthorId),
+      notIn: blockedIds,
+    },
+  };
+}
+
+export const xprisma = prisma.$extends({
+  query: {
+    post: {
+      findMany: async ({ args, query }) => {
+        await applyBlockFilter(args);
+        return query(args);
+      },
+      findFirst: async ({ args, query }) => {
+        await applyBlockFilter(args);
+        return query(args);
+      },
+    },
+  },
+});


### PR DESCRIPTION
## 한 줄 요약
- 이 PR이 하는 일: repository에서 prisma를 이용해서 findMany, findFirst 사용 시 자동으로 차단된 유저는 제외하는 쿼리문을 prisma extends로 자동으로 추가

## 변경 내용
- src/xprisma.js 파일 추가
- 

## 관련 이슈
- closes #9 

## 확인 방법
- 어떻게 실행/테스트했는지:
- 확인한 시나리오:
  1. 사용 시 아래의 코드 형태와 같이 사용하면 됨. import 시에는 기존 prisma가 아닌 수정된 xprisma에서 from하여 사용
  
 xprisma.post.findMany({
  where: {
    blockerId: 123,
    published: true,
  }
})


## 체크리스트
- [ ] 코드가 의도대로 동작함
- [ ] 예외/실패 상황도 고려함 (또는 N/A)
- [ ] 테스트 추가/수정함 (또는 N/A)
- [ ] 문서/설명 업데이트함 (또는 N/A)
