### PR TITLE
Feat: 알림 설정 조회/수정 API 및 관련 스키마 수정 (#33)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,12 +57,10 @@ model User {
 }
 
 model UserNotificationSetting {
-  userId                Int      @id @map("user_id")
-  letterEnabled         Boolean  @map("letter_enabled")
-  replyEnabled          Boolean  @map("reply_enabled")
-  weeklyReportEnabled   Boolean  @map("weekly_report_enabled")
-  marketingEnabled      Boolean  @map("marketing_enabled")
-  updatedAt             DateTime @default(now()) @updatedAt @map("updated_at")
+  userId           Int      @id @map("user_id")
+  letterEnabled    Boolean  @default(true)  @map("letter_enabled")
+  marketingEnabled Boolean  @default(false) @map("marketing_enabled")
+  updatedAt        DateTime @default(now()) @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -1,0 +1,32 @@
+import { updateMyNotificationSettings } from "../services/notification.service.js";
+import { getMyNotificationSettings } from "../services/notification.service.js";
+
+export const handleUpdateMyNotificationSettings = async (req, res, next) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) throw new Error("인증 정보가 없습니다.");
+
+    const { letter, marketing } = req.body;
+
+    const result = await updateMyNotificationSettings({ userId, letter, marketing });
+
+    return res.status(200).success(result); // { updated: true }
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 알람 설정 조회
+
+export const handleGetMyNotificationSettings = async (req, res, next) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) throw new Error("인증 정보가 없습니다.");
+
+    const result = await getMyNotificationSettings({ userId });
+
+    return res.status(200).success(result); // { letter: true, marketing: false }
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { handleSendMyLetter, handleSendOtherLetter } from "./controllers/letter.
 import { handleCheckDuplicatedEmail, handleLogin, handleRefreshToken, handleSignUp, handleSendVerifyEmailCode, handleCheckEmailCode, handleGetAccountInfo, handleResetPassword, handleLogout, handleWithdrawUser } from "./controllers/auth.controller.js";
 import { handlePatchOnboardingStep1 } from "./controllers/user.controller.js";
 import {handleGetAllInterests,handleGetMyInterests,handleUpdateMyOnboardingInterests,} from "./controllers/interest.controller.js";
+import { handleGetMyNotificationSettings, handleUpdateMyNotificationSettings } from "./controllers/notification.controller.js";
 
 dotenv.config();
 
@@ -178,6 +179,12 @@ app.patch("/users/me/onboarding", isLogin, handlePatchOnboardingStep1);
 app.get("/interests/all", handleGetAllInterests); // 전체 목록 (로그인 불필요)
 app.get("/interests", isLogin, handleGetMyInterests); // 내 선택 목록 (로그인 필요)
 app.put("/users/me/onboarding/interests", isLogin, handleUpdateMyOnboardingInterests);
+
+// 알람 설정
+// patch 
+app.patch("/users/me/notification-settings", isLogin, handleUpdateMyNotificationSettings);
+// get
+app.get("/users/me/notification-settings", isLogin, handleGetMyNotificationSettings);
 
 // 서버 실행
 app.listen(port, async () => {

--- a/src/repositories/notification.repository.js
+++ b/src/repositories/notification.repository.js
@@ -1,0 +1,81 @@
+import { prisma } from "../configs/db.config.js";
+
+/**
+ * 알림 설정 조회
+ */
+export const findNotificationSettingByUserId = async (userId) => {
+  return prisma.userNotificationSetting.findUnique({
+    where: { userId },
+    select: {
+      userId: true,
+      letterEnabled: true,
+      marketingEnabled: true,
+      updatedAt: true,
+    },
+  });
+};
+
+/**
+ * 알림 설정 생성 (기본값은 Prisma schema default를 따름)
+ */
+export const createNotificationSetting = async ({ userId, letterEnabled, marketingEnabled }) => {
+  return prisma.userNotificationSetting.create({
+    data: {
+      userId,
+      // 값이 undefined면 DB default 사용
+      ...(typeof letterEnabled === "boolean" ? { letterEnabled } : {}),
+      ...(typeof marketingEnabled === "boolean" ? { marketingEnabled } : {}),
+    },
+    select: { userId: true },
+  });
+};
+
+/**
+ * 알림 설정 업데이트
+ */
+export const updateNotificationSetting = async ({ userId, letterEnabled, marketingEnabled }) => {
+  return prisma.userNotificationSetting.update({
+    where: { userId },
+    data: {
+      ...(typeof letterEnabled === "boolean" ? { letterEnabled } : {}),
+      ...(typeof marketingEnabled === "boolean" ? { marketingEnabled } : {}),
+    },
+    select: { userId: true },
+  });
+};
+
+/**
+ * upsert (없으면 생성)
+ */
+export const upsertNotificationSetting = async ({ userId, letterEnabled, marketingEnabled }) => {
+  return prisma.userNotificationSetting.upsert({
+    where: { userId },
+    update: {
+      ...(typeof letterEnabled === "boolean" ? { letterEnabled } : {}),
+      ...(typeof marketingEnabled === "boolean" ? { marketingEnabled } : {}),
+    },
+    create: {
+      userId,
+      ...(typeof letterEnabled === "boolean" ? { letterEnabled } : {}),
+      ...(typeof marketingEnabled === "boolean" ? { marketingEnabled } : {}),
+    },
+    select: { userId: true },
+  });
+};
+
+// 알람 설정 조회 (없으면 기본값으로 생성)
+
+export const findOrCreateNotificationSetting = async ({ userId }) => {
+  // 없으면 기본값(Prisma default)으로 생성
+  return prisma.userNotificationSetting.upsert({
+    where: { userId },
+    update: {}, // 조회 목적이라 update 없음
+    create: { userId },
+    select: {
+      userId: true,
+      letterEnabled: true,
+      marketingEnabled: true,
+      updatedAt: true,
+    },
+  });
+};

--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -1,0 +1,36 @@
+import { upsertNotificationSetting } from "../repositories/notification.repository.js";
+import { findOrCreateNotificationSetting } from "../repositories/notification.repository.js";
+
+export const updateMyNotificationSettings = async ({ userId, letter, marketing }) => {
+  // body 검증
+  if (typeof letter !== "boolean" && typeof marketing !== "boolean") {
+    throw new Error('요청 바디에 "letter" 또는 "marketing" 중 하나 이상이 boolean으로 필요합니다.');
+  }
+  if (typeof letter !== "undefined" && typeof letter !== "boolean") {
+    throw new Error('"letter"는 boolean이어야 합니다.');
+  }
+  if (typeof marketing !== "undefined" && typeof marketing !== "boolean") {
+    throw new Error('"marketing"은 boolean이어야 합니다.');
+  }
+
+  await upsertNotificationSetting({
+    userId,
+    letterEnabled: letter,
+    marketingEnabled: marketing,
+  });
+
+  return { updated: true };
+};
+
+
+// 알람 설정 조회 (없으면 기본값으로 생성)
+
+export const getMyNotificationSettings = async ({ userId }) => {
+  const setting = await findOrCreateNotificationSetting({ userId });
+
+  // 프론트 요청/응답 형태에 맞춰 key 변환
+  return {
+    letter: setting.letterEnabled,
+    marketing: setting.marketingEnabled,
+  };
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

ex) feature/#33-설정-관련-api-구현-v2 -> develop

### 변경 사항
- 로컬 mysql 도커 실행 파일 추가 (작업하는데 지장 생기지 않도록 로컬에도 만들어주시면 감사하겠습니다)
- 편지 관련 에셋 목록 조회 API 구현
- 나/친구/타인에게 편지 전송 API 구현
- user레포지토리의 findUserById 인자 변경 (payload -> id)
- 폰트 테이블에 assetUrl 컬럼 추가

### 테스트 결과
- 알림 설정 조회 (get)
<img width="1918" height="1016" alt="알림 설정 get (초기)" src="https://github.com/user-attachments/assets/727306eb-dfcf-4e63-bde6-270043df6ac5" />

- 알림 설정 수정 (patch)
<img width="1918" height="1015" alt="알림 설정 patch" src="https://github.com/user-attachments/assets/0bd63c87-cf24-4561-b27d-c0b952448a79" />


- 알림 설정 수정 후 조회 (get)
<img width="1918" height="1010" alt="알림 설정 get (수정 이후)" src="https://github.com/user-attachments/assets/9f52c3ae-1ee4-43cc-9b19-627f8bdf3440" />
