### PR TITLE
Feat: 공지/정책 조회 API 구현 (#46)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -523,13 +523,16 @@ model Restriction {
 model Notice {
   id        Int      @id @default(autoincrement()) @map("id")
   title     String   @map("title")
+  summary   String?  @db.VarChar(255) @map("summary") // 목록용 요약(선택)
   content   String   @db.Text @map("content")
-  pinned    Boolean  @map("pinned")
+  pinned    Boolean  @default(false) @map("pinned")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
+  @@index([createdAt])
   @@map("notice")
 }
+
 
 model PolicyDocument {
   key         String   @id @map("key")
@@ -540,3 +543,5 @@ model PolicyDocument {
 
   @@map("policy_document")
 }
+
+

--- a/src/controllers/notice.controller.js
+++ b/src/controllers/notice.controller.js
@@ -1,0 +1,20 @@
+import { getNoticeDetail, getNotices } from "../services/notice.service.js";
+
+export const handleGetNotices = async (req, res, next) => {
+  try {
+    const data = await getNotices();
+    return res.status(200).json({ resultType: "SUCCESS", error: null, success: data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const handleGetNoticeDetail = async (req, res, next) => {
+  try {
+    const { noticeId } = req.params;
+    const data = await getNoticeDetail(noticeId);
+    return res.status(200).json({ resultType: "SUCCESS", error: null, success: data });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controllers/policy.controller.js
+++ b/src/controllers/policy.controller.js
@@ -1,0 +1,28 @@
+import { getCommunityGuidelines, getPrivacy, getTerms } from "../services/policy.service.js";
+
+export const handleGetCommunityGuidelines = async (req, res, next) => {
+  try {
+    const data = await getCommunityGuidelines();
+    return res.status(200).json({ resultType: "SUCCESS", error: null, success: data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const handleGetTerms = async (req, res, next) => {
+  try {
+    const data = await getTerms();
+    return res.status(200).json({ resultType: "SUCCESS", error: null, success: data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const handleGetPrivacy = async (req, res, next) => {
+  try {
+    const data = await getPrivacy();
+    return res.status(200).json({ resultType: "SUCCESS", error: null, success: data });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/errors/notice.error.js
+++ b/src/errors/notice.error.js
@@ -1,0 +1,18 @@
+export class NoticeNotFoundError extends Error {
+    constructor(noticeId) {
+      super(`해당 공지사항을 찾을 수 없습니다. noticeId=${noticeId}`);
+      this.name = "NoticeNotFoundError";
+      this.statusCode = 404;
+      this.code = "NOTICE_NOT_FOUND";
+    }
+  }
+  
+  export class InvalidNoticeIdError extends Error {
+    constructor(noticeId) {
+      super(`noticeId는 양의 정수여야 합니다. noticeId=${noticeId}`);
+      this.name = "InvalidNoticeIdError";
+      this.statusCode = 400;
+      this.code = "INVALID_NOTICE_ID";
+    }
+  }
+  

--- a/src/errors/policy.error.js
+++ b/src/errors/policy.error.js
@@ -1,0 +1,9 @@
+export class PolicyNotFoundError extends Error {
+    constructor(key) {
+      super(`해당 정책 문서를 찾을 수 없습니다. key=${key}`);
+      this.name = "PolicyNotFoundError";
+      this.statusCode = 404;
+      this.code = "POLICY_NOT_FOUND";
+    }
+  }
+  

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,11 @@ import { handlePostMatchingSession, handlePatchMatchingSessionStatusDiscarded, h
 import { handlePatchOnboardingStep1 } from "./controllers/user.controller.js";
 import {handleGetAllInterests,handleGetMyInterests,handleUpdateMyOnboardingInterests,} from "./controllers/interest.controller.js";
 import { handleGetMyNotificationSettings, handleUpdateMyNotificationSettings } from "./controllers/notification.controller.js";
+import {handleGetCommunityGuidelines,handleGetTerms,handleGetPrivacy,} from "./controllers/policy.controller.js";
+import {handleGetNotices,handleGetNoticeDetail,} from "./controllers/notice.controller.js";
+
+
+
 
 dotenv.config();
 
@@ -201,6 +206,16 @@ app.use((err, req, res, next) => {
     success: null,
   });
 });
+
+// 정책, 공지사항
+app.get("/policies/community-guidelines", handleGetCommunityGuidelines);
+app.get("/policies/terms", handleGetTerms);
+app.get("/policies/privacy", handleGetPrivacy);
+
+app.get("/notices", handleGetNotices);
+app.get("/notices/:noticeId", handleGetNoticeDetail);
+
+
 
 // 서버 실행
 app.listen(port, async () => {

--- a/src/repositories/notice.repository.js
+++ b/src/repositories/notice.repository.js
@@ -1,0 +1,28 @@
+import { prisma } from "../configs/db.config.js";
+
+export const findActiveNotices = async () => {
+
+  return prisma.notice.findMany({
+    orderBy: [{ pinned: "desc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      title: true,
+      summary: true,
+      pinned: true,
+      createdAt: true,
+    },
+  });
+};
+
+export const findNoticeById = async (id) => {
+  return prisma.notice.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      title: true,
+      content: true,
+      pinned: true,
+      createdAt: true,
+    },
+  });
+};

--- a/src/repositories/policy.repository.js
+++ b/src/repositories/policy.repository.js
@@ -1,0 +1,14 @@
+import { prisma } from "../configs/db.config.js";
+
+export const findPolicyDocumentByKey = async (key) => {
+  return prisma.policyDocument.findUnique({
+    where: { key },
+    select: {
+      key: true,
+      content: true,
+      version: true,
+      effectiveAt: true,
+      updatedAt: true,
+    },
+  });
+};

--- a/src/services/notice.service.js
+++ b/src/services/notice.service.js
@@ -1,0 +1,17 @@
+import { findActiveNotices, findNoticeById } from "../repositories/notice.repository.js";
+import { InvalidNoticeIdError, NoticeNotFoundError } from "../errors/notice.error.js";
+
+export const getNotices = async () => {
+  const items = await findActiveNotices();
+  return { items };
+};
+
+export const getNoticeDetail = async (noticeId) => {
+  const id = Number(noticeId);
+  if (!Number.isInteger(id) || id <= 0) throw new InvalidNoticeIdError(noticeId);
+
+  const notice = await findNoticeById(id);
+  if (!notice) throw new NoticeNotFoundError(id);
+
+  return notice;
+};

--- a/src/services/policy.service.js
+++ b/src/services/policy.service.js
@@ -1,0 +1,38 @@
+import { findPolicyDocumentByKey } from "../repositories/policy.repository.js";
+import { PolicyNotFoundError } from "../errors/policy.error.js";
+
+const POLICY_KEYS = {
+  COMMUNITY_GUIDELINES: "COMMUNITY_GUIDELINES",
+  TERMS: "TERMS",
+  PRIVACY: "PRIVACY",
+};
+
+export const getCommunityGuidelines = async () => {
+  const doc = await findPolicyDocumentByKey(POLICY_KEYS.COMMUNITY_GUIDELINES);
+  if (!doc) throw new PolicyNotFoundError(POLICY_KEYS.COMMUNITY_GUIDELINES);
+
+  return {
+    title: "커뮤니티 가이드라인",
+    content: doc.content,
+  };
+};
+
+export const getTerms = async () => {
+  const doc = await findPolicyDocumentByKey(POLICY_KEYS.TERMS);
+  if (!doc) throw new PolicyNotFoundError(POLICY_KEYS.TERMS);
+
+  return {
+    title: "서비스 이용약관",
+    content: doc.content,
+  };
+};
+
+export const getPrivacy = async () => {
+  const doc = await findPolicyDocumentByKey(POLICY_KEYS.PRIVACY);
+  if (!doc) throw new PolicyNotFoundError(POLICY_KEYS.PRIVACY);
+
+  return {
+    title: "개인정보 처리방침",
+    content: doc.content,
+  };
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

ex) feature/#46-공지정책관련api -> develop

### 변경 사항

커뮤니티 가이드라인 조회, 서비스 이용약관 조회, 개인정보 처리방침 조회, 공지사항 목록 조회, 공지사항 상세 조회 기능을 추가했습니다.

### 테스트 결과
- 커뮤니티 가이드라인 조회
<img width="1919" height="1029" alt="커뮤니티 가이드 라인 조회" src="https://github.com/user-attachments/assets/5f525148-4fe4-4651-afaa-0031711e653f" />

- 서비스 이용약관 조회
<img width="1919" height="1031" alt="서비스 이용약관 조회" src="https://github.com/user-attachments/assets/4d4035c9-1d7d-4324-8527-a41e425df958" />

- 개인정보 처리방침 조회
<img width="1919" height="1027" alt="개인정보 처리방침 조회" src="https://github.com/user-attachments/assets/cdc27757-c4e6-4d4b-89de-6dfbb5cfd1ad" />

- 공지사항 목록 조회
<img width="1919" height="1030" alt="공지사항 목록 조회" src="https://github.com/user-attachments/assets/7211e978-35d4-4e15-a071-89b934a41726" />

- 공지사항 상세 조회
<img width="1919" height="1032" alt="공지사항 상세 조회" src="https://github.com/user-attachments/assets/9c50141e-bc74-48c4-8a87-b2c8c1c386fe" />

