### PR TITLE
Feat: 정보 동의 설정/디바이스 토큰 갱신 API 구현 (#48)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,7 +69,7 @@ model UserNotificationSetting {
 
 model UserDeviceToken {
   id          Int      @id @default(autoincrement()) @map("id")
-  userId      Int      @map("user_id")
+  userId      Int      @unique @map("user_id")  
   deviceType  String   @map("device_type")
   deviceToken String   @map("device_token")
   lastSeenAt  DateTime @default(now()) @map("last_seen_at")
@@ -77,13 +77,13 @@ model UserDeviceToken {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([userId])
+  @@index([userId]) 
   @@map("user_device_token")
 }
 
 model UserAgreement {
   id              Int      @id @default(autoincrement()) @map("id")
-  userId          Int      @map("user_id")
+  userId          Int      @unique @map("user_id")   // ✅ 여기에 @unique 추가
   termsAgreed     Boolean  @map("terms_agreed")
   privacyAgreed   Boolean  @map("privacy_agreed")
   ageOver14Agreed Boolean  @map("age_over_14_agreed")

--- a/src/controllers/consent.controller.js
+++ b/src/controllers/consent.controller.js
@@ -1,0 +1,50 @@
+import { getMyConsents, patchMyConsents } from "../services/consent.service.js";
+
+export const handleGetMyConsents = async (req, res) => {
+  try {
+    const userId = req.user?.id;
+
+    const result = await getMyConsents({ userId });
+
+    return res.status(200).json({
+      resultType: "SUCCESS",
+      error: null,
+      success: result,
+    });
+  } catch (err) {
+    const status = err.status ?? 500;
+    const code = err.code ?? "INTERNAL_SERVER_ERROR";
+    const message = err.message ?? "서버 내부 오류";
+
+    return res.status(status).json({
+      resultType: "ERROR",
+      error: { code, message },
+      success: null,
+    });
+  }
+};
+
+export const handlePatchMyConsents = async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    const payload = req.body ?? {};
+
+    const result = await patchMyConsents({ userId, payload });
+
+    return res.status(200).json({
+      resultType: "SUCCESS",
+      error: null,
+      success: result,
+    });
+  } catch (err) {
+    const status = err.status ?? 500;
+    const code = err.code ?? "INTERNAL_SERVER_ERROR";
+    const message = err.message ?? "서버 내부 오류";
+
+    return res.status(status).json({
+      resultType: "ERROR",
+      error: { code, message },
+      success: null,
+    });
+  }
+};

--- a/src/controllers/deviceToken.controller.js
+++ b/src/controllers/deviceToken.controller.js
@@ -1,0 +1,26 @@
+import { updateMyDeviceToken } from "../services/deviceToken.service.js";
+
+export const handlePutMyDeviceToken = async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    const { deviceToken } = req.body ?? {};
+
+    const result = await updateMyDeviceToken({ userId, deviceToken });
+
+    return res.status(200).json({
+      resultType: "SUCCESS",
+      error: null,
+      success: result,
+    });
+  } catch (err) {
+    const status = err.status ?? 500;
+    const code = err.code ?? "INTERNAL_SERVER_ERROR";
+    const message = err.message ?? "서버 내부 오류";
+
+    return res.status(status).json({
+      resultType: "ERROR",
+      error: { code, message },
+      success: null,
+    });
+  }
+};

--- a/src/errors/consent.error.js
+++ b/src/errors/consent.error.js
@@ -1,0 +1,21 @@
+export class ConsentError extends Error {
+    constructor({ status = 400, code = "CONSENT_ERROR", message = "정보 동의 오류" }) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  }
+  
+  export const CONSENT_ERRORS = {
+    UNAUTHORIZED: new ConsentError({
+      status: 401,
+      code: "UNAUTHORIZED",
+      message: "인증이 필요합니다.",
+    }),
+    INVALID_BODY: new ConsentError({
+      status: 400,
+      code: "INVALID_BODY",
+      message: "요청 바디가 올바르지 않습니다. (termsAgreed/privacyAgreed/marketingAgreed/ageOver14Agreed 중 일부 boolean)",
+    }),
+  };
+  

--- a/src/errors/deviceToken.error.js
+++ b/src/errors/deviceToken.error.js
@@ -1,0 +1,20 @@
+export class DeviceTokenError extends Error {
+  constructor({ status = 400, code = "DEVICE_TOKEN_ERROR", message = "디바이스 토큰 오류" }) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export const DEVICE_TOKEN_ERRORS = {
+  UNAUTHORIZED: new DeviceTokenError({
+    status: 401,
+    code: "UNAUTHORIZED",
+    message: "인증이 필요합니다.",
+  }),
+  INVALID_BODY: new DeviceTokenError({
+    status: 400,
+    code: "INVALID_BODY",
+    message: "요청 바디가 올바르지 않습니다. (deviceToken: string 필수)",
+  }),
+};

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ import {handleGetAllInterests,handleGetMyInterests,handleUpdateMyOnboardingInter
 import { handleGetMyNotificationSettings, handleUpdateMyNotificationSettings } from "./controllers/notification.controller.js";
 import {handleGetCommunityGuidelines,handleGetTerms,handleGetPrivacy,} from "./controllers/policy.controller.js";
 import {handleGetNotices,handleGetNoticeDetail,} from "./controllers/notice.controller.js";
+import { handlePutMyDeviceToken } from "./controllers/deviceToken.controller.js";
+import { handleGetMyConsents, handlePatchMyConsents } from "./controllers/consent.controller.js";
 
 
 
@@ -215,7 +217,12 @@ app.get("/policies/privacy", handleGetPrivacy);
 app.get("/notices", handleGetNotices);
 app.get("/notices/:noticeId", handleGetNoticeDetail);
 
+// 동의 설정
+app.get("/users/me/consents", isLogin, handleGetMyConsents);
+app.patch("/users/me/consents", isLogin, handlePatchMyConsents);
 
+// 디바이스 토큰
+app.put("/users/me/device-tokens", isLogin, handlePutMyDeviceToken);
 
 // 서버 실행
 app.listen(port, async () => {

--- a/src/repositories/consent.repository.js
+++ b/src/repositories/consent.repository.js
@@ -1,0 +1,38 @@
+import { prisma } from "../configs/db.config.js";
+
+export const findUserAgreementByUserId = async (userId) => {
+  return prisma.userAgreement.findUnique({
+    where: { userId },
+    select: {
+      termsAgreed: true,
+      privacyAgreed: true,
+      marketingAgreed: true,
+      ageOver14Agreed: true,
+    },
+  });
+};
+
+export const upsertUserAgreement = async ({ userId, data }) => {
+  return prisma.userAgreement.upsert({
+    where: { userId }, // userId @unique 필요
+    update: {
+      ...data,
+      agreedAt: new Date(),
+    },
+    create: {
+      userId,
+      // 없으면 기본 false로 생성
+      termsAgreed: data.termsAgreed ?? false,
+      privacyAgreed: data.privacyAgreed ?? false,
+      marketingAgreed: data.marketingAgreed ?? false,
+      ageOver14Agreed: data.ageOver14Agreed ?? false,
+      agreedAt: new Date(),
+    },
+    select: {
+      termsAgreed: true,
+      privacyAgreed: true,
+      marketingAgreed: true,
+      ageOver14Agreed: true,
+    },
+  });
+};

--- a/src/repositories/deviceToken.repository.js
+++ b/src/repositories/deviceToken.repository.js
@@ -1,0 +1,20 @@
+import { prisma } from "../configs/db.config.js";
+
+export const upsertUserDeviceToken = async ({ userId, deviceToken, deviceType = "FCM" }) => {
+  // userId가 @unique라서 where에 userId 사용 가능
+  return prisma.userDeviceToken.upsert({
+    where: { userId },
+    update: {
+      deviceToken,
+      deviceType,
+      lastSeenAt: new Date(),
+    },
+    create: {
+      userId,
+      deviceToken,
+      deviceType,
+      lastSeenAt: new Date(),
+    },
+    select: { id: true, userId: true },
+  });
+};

--- a/src/services/consent.service.js
+++ b/src/services/consent.service.js
@@ -1,0 +1,44 @@
+import { findUserAgreementByUserId, upsertUserAgreement } from "../repositories/consent.repository.js";
+import { CONSENT_ERRORS } from "../errors/consent.error.js";
+
+const isBooleanOrUndefined = (v) => typeof v === "boolean" || typeof v === "undefined";
+
+export const getMyConsents = async ({ userId }) => {
+  if (!userId) throw CONSENT_ERRORS.UNAUTHORIZED;
+
+  const agreement = await findUserAgreementByUserId(userId);
+
+
+  const safe = agreement ?? (await upsertUserAgreement({ userId, data: {} }));
+
+  
+  return {
+    termsAgreed: safe.termsAgreed,
+    privacyAgreed: safe.privacyAgreed,
+  };
+};
+
+export const patchMyConsents = async ({ userId, payload }) => {
+  if (!userId) throw CONSENT_ERRORS.UNAUTHORIZED;
+
+  const { termsAgreed, privacyAgreed, marketingAgreed, ageOver14Agreed } = payload ?? {};
+
+  if (
+    !isBooleanOrUndefined(termsAgreed) ||
+    !isBooleanOrUndefined(privacyAgreed) ||
+    !isBooleanOrUndefined(marketingAgreed) ||
+    !isBooleanOrUndefined(ageOver14Agreed)
+  ) {
+    throw CONSENT_ERRORS.INVALID_BODY;
+  }
+
+  const updateData = {};
+  if (typeof termsAgreed === "boolean") updateData.termsAgreed = termsAgreed;
+  if (typeof privacyAgreed === "boolean") updateData.privacyAgreed = privacyAgreed;
+  if (typeof marketingAgreed === "boolean") updateData.marketingAgreed = marketingAgreed;
+  if (typeof ageOver14Agreed === "boolean") updateData.ageOver14Agreed = ageOver14Agreed;
+
+  await upsertUserAgreement({ userId, data: updateData });
+
+  return { updated: true };
+};

--- a/src/services/deviceToken.service.js
+++ b/src/services/deviceToken.service.js
@@ -1,0 +1,17 @@
+import { upsertUserDeviceToken } from "../repositories/deviceToken.repository.js";
+import { DEVICE_TOKEN_ERRORS } from "../errors/deviceToken.error.js";
+
+export const updateMyDeviceToken = async ({ userId, deviceToken }) => {
+  if (!userId) throw DEVICE_TOKEN_ERRORS.UNAUTHORIZED;
+  if (typeof deviceToken !== "string" || deviceToken.trim().length === 0) {
+    throw DEVICE_TOKEN_ERRORS.INVALID_BODY;
+  }
+
+  await upsertUserDeviceToken({
+    userId,
+    deviceToken: deviceToken.trim(),
+    deviceType: "FCM", 
+  });
+
+  return { updated: true };
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#48-정보동의설정디바이스토큰갱신API구현 -> develop

### 변경 사항

ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
- 디바이스 토큰 갱신
<img width="1919" height="1027" alt="디바이스 토큰 갱신" src="https://github.com/user-attachments/assets/e4eed903-824e-4dc1-a127-2c3cf4fc04fe" />

- 정보 동의 설정 조희
<img width="1919" height="1030" alt="정보 동의 설정 조회" src="https://github.com/user-attachments/assets/d993b664-1da2-4905-97c6-1c4f8d974a00" />

- 정보 동의 설정 갱신
<img width="1919" height="1037" alt="정보 동의 설정 갱신" src="https://github.com/user-attachments/assets/536a0a14-6eaa-44df-9e05-ffdae9151ecd" />

