### PR TITLE
Feat: 편지함 조회 API 구현 (#53)

### DIFF
--- a/src/controllers/mailbox.controller.js
+++ b/src/controllers/mailbox.controller.js
@@ -1,0 +1,59 @@
+import {
+    getAnonymousThreads,
+    getAnonymousThreadLetters,
+    getSelfMailbox,
+  } from "../services/mailbox.service.js";
+  import { MAILBOX_ERROR, throwMailboxError } from "../errors/mailbox.error.js";
+  
+  const getAuthUserId = (req) => req.user?.id ?? req.userId ?? req.user?.userId ?? null;
+  
+  export const handleGetAnonymousThreads = async (req, res, next) => {
+    try {
+      const userId = getAuthUserId(req);
+      if (!userId) throwMailboxError(MAILBOX_ERROR.UNAUTHORIZED);
+  
+      const result = await getAnonymousThreads(userId);
+      return res.status(200).json({
+        resultType: "SUCCESS",
+        error: null,
+        success: result,
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+  
+  export const handleGetAnonymousThreadLetters = async (req, res, next) => {
+    try {
+      const userId = getAuthUserId(req);
+      if (!userId) throwMailboxError(MAILBOX_ERROR.UNAUTHORIZED);
+  
+      const { threadId } = req.params;
+      const result = await getAnonymousThreadLetters(userId, threadId);
+  
+      return res.status(200).json({
+        resultType: "SUCCESS",
+        error: null,
+        success: result,
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+  
+  export const handleGetSelfMailbox = async (req, res, next) => {
+    try {
+      const userId = getAuthUserId(req);
+      if (!userId) throwMailboxError(MAILBOX_ERROR.UNAUTHORIZED);
+  
+      const result = await getSelfMailbox(userId);
+      return res.status(200).json({
+        resultType: "SUCCESS",
+        error: null,
+        success: result,
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+  

--- a/src/errors/mailbox.error.js
+++ b/src/errors/mailbox.error.js
@@ -1,0 +1,22 @@
+export const MAILBOX_ERROR = {
+    UNAUTHORIZED: {
+      statusCode: 401,
+      errorCode: "MAILBOX_UNAUTHORIZED",
+      message: "인증이 필요합니다.",
+    },
+    INVALID_THREAD_ID: {
+      statusCode: 400,
+      errorCode: "MAILBOX_INVALID_THREAD_ID",
+      message: "threadId가 올바르지 않습니다.",
+    },
+  };
+  
+  export const throwMailboxError = (errorObj, detail = null) => {
+    const err = new Error(errorObj.message);
+    err.statusCode = errorObj.statusCode;
+    err.errorCode = errorObj.errorCode;
+    err.reason = errorObj.message;
+    err.data = detail ?? null;
+    throw err;
+  };
+  

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import {handleGetNotices,handleGetNoticeDetail,} from "./controllers/notice.cont
 import { handlePutMyDeviceToken } from "./controllers/deviceToken.controller.js";
 import { handleGetMyConsents, handlePatchMyConsents } from "./controllers/consent.controller.js";
 import { HandleGetHomeDashboard } from "./controllers/dashboard.controller.js";
-
+import {handleGetAnonymousThreads,handleGetAnonymousThreadLetters,handleGetSelfMailbox,} from "./controllers/mailbox.controller.js";
 
 
 
@@ -234,6 +234,12 @@ app.patch("/users/me/consents", isLogin, handlePatchMyConsents);
 
 // 디바이스 토큰
 app.put("/users/me/device-tokens", isLogin, handlePutMyDeviceToken);
+
+// / 편지함
+app.get("/mailbox/anonymous", isLogin, handleGetAnonymousThreads);
+app.get("/mailbox/anonymous/threads/:threadId/letters", isLogin, handleGetAnonymousThreadLetters);
+app.get("/mailbox/self", isLogin, handleGetSelfMailbox);
+
 
 // 서버 실행
 app.listen(port, async () => {

--- a/src/repositories/mailbox.repository.js
+++ b/src/repositories/mailbox.repository.js
@@ -1,0 +1,88 @@
+import { prisma } from "../configs/db.config.js";
+
+/**
+ * 익명 스레드 목록용:
+ * - receiverUserId = me
+ * - letterType = ANON_SESSION
+ * - senderUserId별 최신 편지 1개씩 뽑기 위해, 일단 최신순 전체를 가져오고 service에서 group 처리
+ */
+export const findReceivedLettersForThreads = async ({ userId, letterType }) => {
+  return prisma.letter.findMany({
+    where: {
+      receiverUserId: userId,
+      letterType,
+    },
+    orderBy: [{ deliveredAt: "desc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      senderUserId: true,
+      title: true,
+      content: true,
+      deliveredAt: true,
+      createdAt: true,
+      design: {
+        select: { paperId: true }, // 편지통 색상용
+      },
+    },
+  });
+};
+
+/**
+ * 특정 익명 스레드(=senderUserId)의 편지 목록
+ */
+export const findReceivedLettersBySender = async ({ userId, senderUserId, letterType }) => {
+  return prisma.letter.findMany({
+    where: {
+      receiverUserId: userId,
+      senderUserId,
+      letterType,
+    },
+    orderBy: [{ deliveredAt: "desc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      title: true,
+      content: true,
+      deliveredAt: true,
+      createdAt: true,
+      design: {
+        select: { paperId: true, stampId: true, fontId: true },
+      },
+    },
+  });
+};
+
+/**
+ * 나에게(SELF) 목록:
+ * - senderUserId = me
+ * - letterType = SELF
+ */
+export const findSelfLetters = async ({ userId, letterType }) => {
+  return prisma.letter.findMany({
+    where: {
+      senderUserId: userId,
+      letterType,
+    },
+    orderBy: [{ createdAt: "desc" }],
+    select: {
+      id: true,
+      title: true,
+      content: true,
+      createdAt: true,
+      deliveredAt: true,
+      design: {
+        select: { paperId: true },
+      },
+    },
+  });
+};
+
+export const findUsersNicknameByIds = async (userIds) => {
+  const rows = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, nickname: true },
+  });
+
+  const map = new Map();
+  for (const r of rows) map.set(r.id, r.nickname ?? null);
+  return map;
+};

--- a/src/services/mailbox.service.js
+++ b/src/services/mailbox.service.js
@@ -1,0 +1,130 @@
+import {
+    findReceivedLettersForThreads,
+    findReceivedLettersBySender,
+    findSelfLetters,
+    findUsersNicknameByIds,
+  } from "../repositories/mailbox.repository.js";
+  import { MAILBOX_ERROR, throwMailboxError } from "../errors/mailbox.error.js";
+  
+
+  const LETTER_TYPE_ANON = "ANON_SESSION";
+  const LETTER_TYPE_SELF = "SELF";
+  
+  const makePreview = (text, maxLen = 30) => {
+    if (!text) return "";
+    const t = String(text);
+    if (t.length <= maxLen) return t;
+    return `${t.slice(0, maxLen)}...`;
+  };
+  
+  /**
+   * 익명 탭 목록 조회
+   * - senderUserId별 최신 편지 1개씩 -> thread 카드
+   * - 편지통 색상: 최신 편지의 design.paperId 사용
+   */
+  export const getAnonymousThreads = async (userId) => {
+    const letters = await findReceivedLettersForThreads({
+      userId,
+      letterType: LETTER_TYPE_ANON,
+    });
+  
+    // senderUserId별 최신 편지 1개 유지
+    const latestBySender = new Map(); // senderUserId -> letter
+    for (const l of letters) {
+      if (!l.senderUserId) continue;
+      if (!latestBySender.has(l.senderUserId)) {
+        latestBySender.set(l.senderUserId, l);
+      }
+    }
+  
+    const senderIds = Array.from(latestBySender.keys());
+    const nicknameMap = senderIds.length ? await findUsersNicknameByIds(senderIds) : new Map();
+  
+    const items = senderIds.map((senderId) => {
+        const l = latestBySender.get(senderId);
+        const updatedAt = l.deliveredAt ?? l.createdAt ?? null;
+      
+        return {
+          threadId: senderId, // threadId = senderUserId
+          lastLetterId: l.id,
+          lastLetterTitle: l.title,
+          lastLetterPreview: makePreview(l.content, 30),
+          updatedAt,
+      
+          //  닉네임 항상 노출
+          sender: {
+            id: senderId,
+            nickname: nicknameMap.get(senderId) ?? null,
+          },
+      
+          //  편지통 색상(=paperId)
+          paperId: l.design?.paperId ?? null,
+        };
+      });
+      
+  
+    // 최신순 정렬
+    items.sort((a, b) => {
+      const ta = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+      const tb = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+      return tb - ta;
+    });
+  
+    return { items };
+  };
+  
+  /**
+   * 특정 익명 스레드의 편지 목록 조회
+   * - 그 senderUserId가 보낸 익명 편지들 목록
+   * - 편지통 색상 = 각 편지의 design.paperId
+   */
+  export const getAnonymousThreadLetters = async (userId, threadIdRaw) => {
+    const threadId = Number(threadIdRaw);
+    if (!Number.isFinite(threadId) || threadId <= 0) {
+      throwMailboxError(MAILBOX_ERROR.INVALID_THREAD_ID, { threadId: threadIdRaw });
+    }
+  
+    const letters = await findReceivedLettersBySender({
+      userId,
+      senderUserId: threadId,
+      letterType: LETTER_TYPE_ANON,
+    });
+  
+    const items = letters.map((l) => ({
+      id: l.id,
+      title: l.title,
+      content: l.content,
+      deliveredAt: l.deliveredAt ?? null,
+      createdAt: l.createdAt ?? null,
+      design: l.design
+        ? {
+            paperId: l.design.paperId ?? null,
+            stampId: l.design.stampId ?? null,
+            fontId: l.design.fontId ?? null,
+          }
+        : { paperId: null, stampId: null, fontId: null },
+    }));
+  
+    return { items };
+  };
+  
+  /**
+   * 나에게(SELF) 편지함 목록 조회
+   * - senderUserId = me AND letterType = SELF
+   */
+  export const getSelfMailbox = async (userId) => {
+    const letters = await findSelfLetters({
+      userId,
+      letterType: LETTER_TYPE_SELF,
+    });
+  
+    const items = letters.map((l) => ({
+      id: l.id,
+      title: l.title,
+      createdAt: l.createdAt ?? null,
+      paperId: l.design?.paperId ?? null, // 편지통 색상
+    }));
+  
+    return { items };
+  };
+  


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

ex) feature/#53-편지함조회API구현 -> develop

### 변경 사항
- 익명 탭 목록 조회 API 추가
- 익명 스레드 편지 목록 조회 API 추가
- 나에게 목록 조회 API 추가

### 테스트 결과
- 익명 탭 목록 조회 API 
<img width="1917" height="1022" alt="익명 탭 목록 조회" src="https://github.com/user-attachments/assets/59f6fba0-d7a4-4089-ab28-7a1c5f5b479e" />

- 익명 스레드 편지 목록 조회 API
<img width="1918" height="1028" alt="익명 스레드 편지 목록 조회" src="https://github.com/user-attachments/assets/30220283-272a-48b7-aff6-08422812b618" />

- 나에게 목록 조회 API 
<img width="1918" height="1027" alt="나에게 편지 목록 조회" src="https://github.com/user-attachments/assets/42b9efe4-61ce-4939-800e-7e0afd90a8b2" />
