### PR TITLE
Feat: 유저 풀 생성 (#65)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   deletedAt       DateTime? @map("deleted_at")
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @default(now()) @updatedAt @map("updated_at")
+  pool            Int       
 
   notificationSetting UserNotificationSetting?
   deviceTokens        UserDeviceToken[]

--- a/src/repositories/interest.repository.js
+++ b/src/repositories/interest.repository.js
@@ -50,3 +50,11 @@ export const replaceUserInterests = async ({ userId, interestIds }) => {
     return true;
   });
 };
+
+export const updateUserPoolByUserId = async ({ userId, userPoolId }) => {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { userPoolId },
+    select: { id: true, userPoolId: true },
+  });
+};

--- a/src/services/interest.service.js
+++ b/src/services/interest.service.js
@@ -1,52 +1,113 @@
 import {
-    findActiveInterests,
-    findMyActiveInterests,
-    findActiveInterestsByIds,
-    replaceUserInterests,
-  } from "../repositories/interest.repository.js";
-  
-  const toIntArray = (arr) => arr.map((v) => Number(v));
-  
-  // 전체 활성 관심사 태그 목록
-  export const getAllInterests = async () => {
-    const items = await findActiveInterests();
-    return { items };
-  };
-  
-  // 내가 선택한 관심사 목록
-  export const getMyInterests = async ({ userId }) => {
-    const items = await findMyActiveInterests(userId);
-    return { items };
-  };
-  
-  // 온보딩 관심사 저장 (최소 3개)
-  export const updateMyOnboardingInterests = async ({ userId, interestIds }) => {
-    if (!Array.isArray(interestIds)) {
-      throw new Error("interestIds는 배열이어야 합니다.");
+  findActiveInterests,
+  findMyActiveInterests,
+  findActiveInterestsByIds,
+  replaceUserInterests,
+  updateUserPoolByUserId,
+} from "../repositories/interest.repository.js";
+
+const toIntArray = (arr) => arr.map((v) => Number(v));
+
+const decideUserPoolIdByInterestIds = (interestIds) => {
+  // id -> pool 매핑 (하드코딩)
+  const ID_TO_POOL = new Map([
+    // Pool 1: 성취/커리어
+    [1, 1], // 공부
+    [4, 1], // 돈
+    [9, 1], // 직장
+    [10, 1], // 취업
+    [11, 1], // 학교
+
+    // Pool 2: 정서/관계
+    [5, 2], // 사랑
+    [6, 2], // 인간관계
+    [13, 2], // 감정
+    [16, 2], // 가족
+
+    // Pool 3: 건강/외형
+    [7, 3], // 건강
+    [12, 3], // 다이어트
+    [17, 3], // 미용
+
+    // Pool 4: 문화/취향
+    [2, 4], // 음악
+    [3, 4], // 영화
+    [8, 4], // 독서
+    [14, 4], // 취미
+    [15, 4], // 여행
+  ]);
+
+  const counts = { 1: 0, 2: 0, 3: 0, 4: 0 };
+
+  for (const id of interestIds) {
+    const pool = ID_TO_POOL.get(id);
+    if (pool) counts[pool] += 1;
+  }
+
+  // 최다 카운트 찾기
+  let max = -1;
+  let winners = [];
+
+  for (const poolId of [1, 2, 3, 4]) {
+    const c = counts[poolId];
+    if (c > max) {
+      max = c;
+      winners = [poolId];
+    } else if (c === max) {
+      winners.push(poolId);
     }
-  
-    const parsed = toIntArray(interestIds);
-  
-    if (parsed.some((n) => !Number.isInteger(n) || n <= 0)) {
-      throw new Error("interestIds는 양의 정수 배열이어야 합니다.");
-    }
-  
-    const uniqueIds = [...new Set(parsed)];
-  
-    // 최소 3개
-    if (uniqueIds.length < 3) {
-      throw new Error("관심사는 최소 3개 선택해야 합니다.");
-    }
-  
-    const found = await findActiveInterestsByIds(uniqueIds);
-    if (found.length !== uniqueIds.length) {
-      const foundSet = new Set(found.map((x) => x.id));
-      const invalid = uniqueIds.filter((id) => !foundSet.has(id));
-      throw new Error(`유효하지 않은 관심사 id가 포함되어 있습니다: ${invalid.join(", ")}`);
-    }
-  
-    await replaceUserInterests({ userId, interestIds: uniqueIds });
-  
-    return { updated: true };
-  };
-  
+  }
+
+  // 전부 0이거나(이론상 없음: id 검증 통과하면), 동률이면 혼합형 5
+  if (max <= 0) return 5;
+  if (winners.length !== 1) return 5;
+
+  return winners[0];
+};
+
+// 전체 활성 관심사 태그 목록
+export const getAllInterests = async () => {
+  const items = await findActiveInterests();
+  return { items };
+};
+
+// 내가 선택한 관심사 목록
+export const getMyInterests = async ({ userId }) => {
+  const items = await findMyActiveInterests(userId);
+  return { items };
+};
+
+// 온보딩 관심사 저장 (최소 3개)
+export const updateMyOnboardingInterests = async ({ userId, interestIds }) => {
+  if (!Array.isArray(interestIds)) {
+    throw new Error("interestIds는 배열이어야 합니다.");
+  }
+
+  const parsed = toIntArray(interestIds);
+
+  if (parsed.some((n) => !Number.isInteger(n) || n <= 0)) {
+    throw new Error("interestIds는 양의 정수 배열이어야 합니다.");
+  }
+
+  const uniqueIds = [...new Set(parsed)];
+
+  // 최소 3개
+  if (uniqueIds.length < 3) {
+    throw new Error("관심사는 최소 3개 선택해야 합니다.");
+  }
+
+  const found = await findActiveInterestsByIds(uniqueIds);
+  if (found.length !== uniqueIds.length) {
+    const foundSet = new Set(found.map((x) => x.id));
+    const invalid = uniqueIds.filter((id) => !foundSet.has(id));
+    throw new Error(
+      `유효하지 않은 관심사 id가 포함되어 있습니다: ${invalid.join(", ")}`
+    );
+  }
+
+  await replaceUserInterests({ userId, interestIds: uniqueIds });
+  const userPoolId = decideUserPoolIdByInterestIds(uniqueIds);
+  await updateUserPoolByUserId({ userId, userPoolId });
+
+  return { updated: true };
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature.#64-유저-풀-생성
ex) feature/#3-로그인구현 -> develop

### 변경 사항
interest.service.js 및 interest.repository.js에서 interest 저장 시 유저 풀을 저장하도록 변경
schema.prisma의 user 테이블에 pool column 추가
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
<img width="2880" height="1800" alt="스크린샷(662)" src="https://github.com/user-attachments/assets/f34f1bbd-3749-445f-b5db-33153303023d" />
<img width="2880" height="1800" alt="스크린샷(663)" src="https://github.com/user-attachments/assets/047cd913-7932-4fb1-bf81-5a26f2b0278e" />

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
