### PR TITLE
Fix: session에 status 추가 및 해당 상태 다루는 모듈 추가 (#95)

### DIFF
--- a/src/repositories/session.repository.js
+++ b/src/repositories/session.repository.js
@@ -1,5 +1,6 @@
 import { prisma } from "../db.config.js";
-import { SessionInternalError } from "../errors/session.error.js";
+import { MaxTurnIsOver, SessionInternalError, SessionNotFoundError } from "../errors/session.error.js";
+import { findRandomUserByPool } from "../repositories/user.repository.js";
 
 export async function existsMatchingSession(userId, targetUserId, questionId) {
   const session = await prisma.MatchingSession.findFirst({
@@ -16,8 +17,28 @@ export async function existsMatchingSession(userId, targetUserId, questionId) {
   return session;
 }
 
-export async function acceptSessionRequestTx(id, targetUserId, questionId) {
+export const decrementSessionTurn = async (sessionId) => {
+  return await prisma.$transaction(async (tx) => {
+    const session = await tx.matchingSession.findUnique({
+      where: { id: sessionId },
+      select: { id: true, maxTurns: true },
+    });
+
+    if (!session) throw new SessionNotFoundError();
+    if (session.maxTurns <= 0) throw new MaxTurnIsOver();
+
+    return await tx.matchingSession.update({
+      where: { id: sessionId },
+      data: { maxTurns: { decrement: 1 } },
+      select: { id: true, maxTurns: true },
+    });
+  });
+};
+
+
+export async function acceptSessionRequestTx(id, questionId) {
   try {
+    const targetUserId = await findRandomUserByPool(id);
     await prisma.$transaction(async (tx) => {
       const sessionResult = await tx.matchingSession.create({
         data: { questionId, status: "IN_PROGRESS" },
@@ -51,17 +72,6 @@ export const insertMatchingSession = async (questionId) => {
   };
 };
 
-export const decrementSessionTurn = async (sessionId) => {
-  return await prisma.matchingSession.update({
-    data: {
-      maxTurns: maxTurns - 1,
-    },
-    where: {
-      id: sessionId,
-    },
-  });
-};
-
 export const updateMatchingSessionToFriends = async (sessionId) => {
   return await prisma.matchingSession.update({
     where: {
@@ -83,6 +93,29 @@ export const updateMatchingSessionToDiscard = async (sessionId) => {
     },
   });
 };
+
+export const updateMatchingSessionToChating = async(sessionId) => {
+  return await prisma.matchingSession.updateMany({
+    where: {
+      id: sessionId
+    },
+    data: {
+      status: "CHATING"
+    }
+  })
+}
+
+export const countMatchingSessionWhichChating = async (userId) => {
+  return await prisma.matchingSession.count({
+    where: {
+      status: "CHATING",
+      participants: {
+        some: { userId },
+      },
+    },
+  });
+};
+
 
 export const insertSessionReview = async (
   id,
@@ -125,3 +158,23 @@ export const findMatchingSessionBySessionId = async(sessionId) => {
         }
     })
 }
+
+export const countMatchingSessionByUserId = async (userId) => {
+  const participants = await prisma.sessionParticipant.findMany({
+    where: { userId },
+    select: { sessionId: true },
+    distinct: ["sessionId"], // 중복 방지 (가능하면 추천)
+  });
+
+  const sessionIds = participants.map((p) => p.sessionId);
+  if (sessionIds.length === 0) return 0;
+
+  const count = await prisma.matchingSession.count({
+    where: {
+      id: { in: sessionIds },
+      status: "PENDING",
+    },
+  });
+
+  return count;
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#95-fix-세션-status-추가-및-모듈-추가 -> dev
ex) feature/#3-로그인구현 -> develop

### 변경 사항
- 세션 상태를 문자열 "PENDING", "CHATING", "FRIENDS", "DISCARDED"로 구분
- 위의 상태는 각 대기, 채팅 중, 친구됨, 친구되지 않고 중지됨
- session.repository.js에 updateMatchingSessionToChating 모듈 추가
- session.repository.js에 countMatchingSessionWhichChating 모듈 추가
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
