### PR TITLE
Fix: feat session api 수정 (#108)

### DIFF
--- a/src/controllers/session.controller.js
+++ b/src/controllers/session.controller.js
@@ -17,7 +17,7 @@ export const handlePostMatchingSession = async(req, res, next) => {
     if(questionId == null || targetUserId == null) throw new UnExpectArgumentsError;
     try{
         const result = await createMatchingSession(userId, targetUserId, questionId);
-        res.status(result.status).json({ data: result.data, message: result.message });
+        res.status(201).success({ data: result.data, message: "세션 매칭이 성공하였습니다." });
     } catch(error) {
         next(error);
     }
@@ -29,7 +29,7 @@ export const handlePatchMatchingSessionStatusFriends = async(req, res, next) => 
     if(sessionId == null) throw new UnExpectArgumentsError;
     try{
         const result = await updateSessionFriends(userId, sessionId);
-        res.status(result.status).json({ data: result.data, message: result.message });
+        res.status(200).success({ data: result.data, message: "세션 상태가 FRIENDS로 변경되었습니다." });
     } catch (error) {
         next(error);
     }
@@ -41,7 +41,7 @@ export const handlePatchMatchingSessionStatusDiscarded = async(req, res, next) =
     if(sessionId == null) throw new UnExpectArgumentsError;
     try{
         const result = await updateSessionDiscarded(userId, sessionId);
-        res.status(result.status).json({ data: result.data, message: result.message });
+        res.status(200).success({ data: result.data, message: "세션 상태가 DISCRADED로 변경되었습니다." });
     } catch (error) {
         next(error);
     }
@@ -55,7 +55,7 @@ export const handlePostSessionReview = async(req, res, next) => {
     if(sessionId == null || userId == null || temperatureScore == null || reviewTag == null) throw new UnExpectArgumentsError;
     try{
         const result = await createSessionReview(sessionId, userId, temperatureScore, reviewTag);
-        res.status(result.status).json({ data: result.data, message: result.message });
+        res.status(201).success({ data: result.data, message: "세션 리뷰 작성에 성공하였습니다." });
     }catch(error){
         next(error);
     }

--- a/src/errors/session.error.js
+++ b/src/errors/session.error.js
@@ -77,3 +77,9 @@ export class SessionCountOverError extends InternalServerError {
     super(code, message, data);
   }
 }
+
+export class SessionFullError extends NotFoundError {
+  constructor(data = null, message = "세션을 맺을 유저가 없습니다.") {
+    super(message, 404, "SESSION_FULL", data);
+  }
+}

--- a/src/errors/session.error.js
+++ b/src/errors/session.error.js
@@ -1,45 +1,79 @@
 import { BadRequestError, NotFoundError, InternalServerError } from "./base.error.js";
+
 /**
- * 400: 자기 자신에게 친구 신청 (FRIEND_400_01)
+ * 400: 올바르지 않은 Arguments 입력 (SESSION_400_01)
  */
-export class SelfFriendRequestError extends BadRequestError {
-  constructor(message = "자기 자신과는 친구 신청을 할 수 없습니다.") {
-    super(message, 400, "FRIEND_400_01", null);
-  }
-}
-
 export class UnExpectArgumentsError extends BadRequestError {
-    constructor(message = "올바르지 않은 Arguments 입력입니다.") {
-        super(message, 400, "SESSION_400_1", null);
-    }
+  constructor(
+    code = "SESSION_400_01",
+    message = "올바르지 않은 Arguments 입력입니다.",
+    data = null
+  ) {
+    super(code, message, data);
+  }
 }
 
+/**
+ * 404: 존재하지 않는 세션 참가자 (SESSION_404_01)
+ */
 export class SessionParticipantNotFoundError extends NotFoundError {
-  constructor(message = "존재하지 않는 세션 참가자입니다.") {
-    super(message, 404, "SESSION_404_1", null);
+  constructor(
+    code = "SESSION_404_01",
+    message = "존재하지 않는 세션 참가자입니다.",
+    data = null
+  ) {
+    super(code, message, data);
   }
 }
 
+/**
+ * 500: 세션 처리 중 서버 오류 (SESSION_500_01)
+ */
 export class SessionInternalError extends InternalServerError {
-  constructor(data = null, message = "친구 처리 중 서버 오류가 발생했습니다.") {
-    super(message, 500, "SESSION_500_01", data);
+  constructor(
+    code = "SESSION_500_01",
+    message = "세션 처리 중 서버 오류가 발생했습니다.",
+    data = null
+  ) {
+    super(code, message, data);
   }
 }
 
+/**
+ * 500: 편지 주고 받은 횟수 초과 (SESSION_500_02)
+ */
 export class MaxTurnIsOver extends InternalServerError {
-  constructor(data = null, message = "편지 주고 받은 횟수가 10번이 되었습니다.") {
-    super(message, 500, "SESSION_500_02", data);
+  constructor(
+    code = "SESSION_500_02",
+    message = "편지 주고 받은 횟수가 10번이 되었습니다.",
+    data = null
+  ) {
+    super(code, message, data);
   }
 }
 
+/**
+ * 404: 세션을 찾을 수 없음 (SESSION_404_02)
+ */
 export class SessionNotFoundError extends NotFoundError {
-  constructor(data = null, message = "세션을 찾을 수 없습니다.") {
-    super(message, 404, "SESSION_404_02", data);
+  constructor(
+    code = "SESSION_404_02",
+    message = "세션을 찾을 수 없습니다.",
+    data = null
+  ) {
+    super(code, message, data);
   }
 }
 
+/**
+ * 500: 세션 개수 초과 (SESSION_500_03)
+ */
 export class SessionCountOverError extends InternalServerError {
-  constructor(data = null, message = "세션이 10개 이상입니다.") {
-    super(message, 500, "SESSION_500_3", data);
+  constructor(
+    code = "SESSION_500_03",
+    message = "세션이 10개 이상입니다.",
+    data = null
+  ) {
+    super(code, message, data);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,21 +24,6 @@ import { bootstrapWeeklyReports } from "./jobs/weeklyReport.bootstrap.js";
 import { startWeeklyReportCron } from "./jobs/weeklyReport.cron.js";
 import { handleGetWeeklyReport } from "./controllers/weeklyReport.controller.js";
 import { handleGetTodayQuestion } from "./controllers/question.controller.js";
-import {
-  handleGetCommunityGuidelines,
-  handleGetTerms,
-  handleGetPrivacy,
-} from "./controllers/policy.controller.js";
-import {
-  handleGetNotices,
-  handleGetNoticeDetail,
-} from "./controllers/notice.controller.js";
-import { handlePutMyDeviceToken } from "./controllers/deviceToken.controller.js";
-import {
-  handleGetMyConsents,
-  handlePatchMyConsents,
-} from "./controllers/consent.controller.js";
-
 import { validate } from "./middlewares/validate.middleware.js";
 import { emailSchema, loginSchema, passwordSchema, SignUpSchema, usernameSchema, verificationConfirmCodeSchema, verificationSendCodeSchema } from "./schemas/auth.schema.js";
 
@@ -50,13 +35,6 @@ import {
 } from "./schemas/letter.schema.js";
 import { idParamSchema } from "./schemas/common.schema.js";
 import { HandleGetHomeDashboard } from "./controllers/dashboard.controller.js";
-import {
-  handleGetAnonymousThreads,
-  handleGetAnonymousThreadLetters,
-  handleGetSelfMailbox,
-  handleGetLetterFromFriend,
-  getLetterFromFriend
-} from "./controllers/mailbox.controller.js";
 import {
   handleInsertUserReport,
   handleGetUserReports,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 // src/index.js
-import "dotenv/config";
 import cors from "cors";
-// import dotenv from "dotenv";
+import dotenv from "dotenv";
 import express from "express";
 import morgan from "morgan";
 import swaggerUi from "swagger-ui-express";
@@ -18,6 +17,7 @@ import { handleSendMyLetter, handleSendOtherLetter, handleGetLetterDetail, handl
 import { handleCheckDuplicatedEmail, handleLogin, handleRefreshToken, handleSignUp, handleSendVerifyEmailCode, handleCheckEmailCode, handleGetAccountInfo, handleResetPassword, handleLogout, handleWithdrawUser, handleCheckDuplicatedUsername } from "./controllers/auth.controller.js";
 import { handlePostMatchingSession, handlePatchMatchingSessionStatusDiscarded, handlePatchMatchingSessionStatusFriends, handlePostSessionReview } from "./controllers/session.controller.js";
 import { handleCreateUserAgreements, handlePatchOnboardingStep1, handleGetAllInterests, handleGetMyInterests, handleUpdateMyOnboardingInterests, handleGetMyNotificationSettings, handleUpdateMyNotificationSettings, handleGetMyProfile, handlePatchMyProfile, handlePostMyProfileImage, handlePutMyDeviceToken, handleGetMyConsents, handlePatchMyConsents, } from "./controllers/user.controller.js";
+import { handleGetAnonymousThreads, handleGetAnonymousThreadLetters, handleGetSelfMailbox, handleGetLetterFromFriend, } from "./controllers/mailbox.controller.js";
 import { handleGetNotices, handleGetNoticeDetail, } from "./controllers/notice.controller.js";
 import { handleGetCommunityGuidelines, handleGetTerms, handleGetPrivacy, } from "./controllers/policy.controller.js";
 import { bootstrapWeeklyReports } from "./jobs/weeklyReport.bootstrap.js";
@@ -39,7 +39,6 @@ import {
   handleInsertUserReport,
   handleGetUserReports,
 } from "./controllers/report.controller.js";
-import { handleGetInquiry, handleInsertInquiryAsAdmin, handleInsertInquiryAsUser } from "./controllers/inquiry.controller.js";
 
 //dotenv.config();
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import { handleGetWeeklyReport } from "./controllers/weeklyReport.controller.js"
 import { handleGetTodayQuestion } from "./controllers/question.controller.js";
 import { validate } from "./middlewares/validate.middleware.js";
 import { emailSchema, loginSchema, passwordSchema, SignUpSchema, usernameSchema, verificationConfirmCodeSchema, verificationSendCodeSchema } from "./schemas/auth.schema.js";
-
+import { handleInsertInquiryAsUser, handleInsertInquiryAsAdmin, handleGetInquiry } from "./controllers/inquiry.controller.js";
 import { isLogin } from "./middlewares/auth.middleware.js";
 import { isRestricted } from "./middlewares/restriction.middleware.js";
 import {

--- a/src/repositories/question.repository.js
+++ b/src/repositories/question.repository.js
@@ -21,3 +21,14 @@ export const findQuestionByDate = async (date) => {
 
     return question;
 }
+
+export const findQuestionByQuestionId = async(id) => {
+    const result = prisma.question.findFirst({
+        where: {
+            id
+        },
+        select: {
+            id: true
+        }
+    })
+}

--- a/src/repositories/session.repository.js
+++ b/src/repositories/session.repository.js
@@ -1,5 +1,10 @@
 import { prisma } from "../db.config.js";
-import { MaxTurnIsOver, SessionInternalError, SessionNotFoundError } from "../errors/session.error.js";
+import {
+  MaxTurnIsOver,
+  SessionInternalError,
+  SessionNotFoundError,
+} from "../errors/session.error.js";
+import { UserNotFoundError } from "../errors/user.error.js";
 import { findRandomUserByPool } from "../repositories/user.repository.js";
 
 export async function existsMatchingSession(userId, targetUserId, questionId) {
@@ -35,40 +40,44 @@ export const decrementSessionTurn = async (sessionId) => {
   });
 };
 
-export const findMaxTurnBySessionId = async(sessionId) => {
+export const findMaxTurnBySessionId = async (sessionId) => {
   const result = await prisma.matchingSession.findFirst({
     where: {
-      id: sessionId
+      id: sessionId,
     },
     select: {
       maxTurns: true,
-    }
-  })
-  if(result.maxTurns <= 0) return false;
+    },
+  });
+  if (result.maxTurns <= 0) return false;
   return true;
-}
+};
 
-export async function acceptSessionRequestTx(id, questionId) {
+export async function acceptSessionRequestTx(userId, questionId) {
   try {
-    const targetUserId = await findRandomUserByPool(id);
-    await prisma.$transaction(async (tx) => {
+    const targetUserId = await findRandomUserByPool(userId);
+    if (!targetUserId)
+      throw new UserNotFoundError(undefined, undefined, { userId });
+    return await prisma.$transaction(async (tx) => {
+      console.log("start");
       const sessionResult = await tx.matchingSession.create({
-        data: { questionId, status: "IN_PROGRESS" },
+        data: { questionId, status: "PENDING" 
+        },
       });
-
+      console.log("sessionResult: "+sessionResult.id);
       const result = await tx.sessionParticipant.createMany({
         data: [
-          { sessionId: sessionResult.id, userId: id },
+          { sessionId: sessionResult.id, userId },
           { sessionId: sessionResult.id, userId: targetUserId },
         ],
       });
 
       if (result.count !== 2) throw new SessionInternalError();
 
-      return true;
+      return sessionResult.id;
     });
   } catch (error) {
-    return false;
+    throw new SessionInternalError(undefined, error.message, undefined);
   }
 }
 
@@ -106,16 +115,16 @@ export const updateMatchingSessionToDiscard = async (sessionId) => {
   });
 };
 
-export const updateMatchingSessionToChating = async(sessionId) => {
+export const updateMatchingSessionToChating = async (sessionId) => {
   return await prisma.matchingSession.updateMany({
     where: {
-      id: sessionId
+      id: sessionId,
     },
     data: {
-      status: "CHATING"
-    }
-  })
-}
+      status: "CHATING",
+    },
+  });
+};
 
 export const countMatchingSessionWhichChating = async (userId) => {
   return await prisma.matchingSession.count({
@@ -127,7 +136,6 @@ export const countMatchingSessionWhichChating = async (userId) => {
     },
   });
 };
-
 
 export const insertSessionReview = async (
   id,
@@ -147,7 +155,10 @@ export const insertSessionReview = async (
   });
 };
 
-export const findSessionParticipantByUserIdAndSessionId = async (id, sessionId) => {
+export const findSessionParticipantByUserIdAndSessionId = async (
+  id,
+  sessionId
+) => {
   const other = await prisma.sessionParticipant.findFirst({
     where: {
       sessionId: sessionId,
@@ -162,14 +173,13 @@ export const findSessionParticipantByUserIdAndSessionId = async (id, sessionId) 
   return other?.userId ?? null;
 };
 
-
-export const findMatchingSessionBySessionId = async(sessionId) => {
-    return await prisma.matchingSession.findFirst({
-        where: {
-            id: sessionId
-        }
-    })
-}
+export const findMatchingSessionBySessionId = async (sessionId) => {
+  return await prisma.matchingSession.findFirst({
+    where: {
+      id: sessionId,
+    },
+  });
+};
 
 export const countMatchingSessionByUserId = async (userId) => {
   const participants = await prisma.sessionParticipant.findMany({

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -2,6 +2,7 @@ import { prisma } from "../configs/db.config.js";
 import { xprisma } from "../xprisma.js";
 import { DuplicatedValueError } from "../errors/base.error.js";
 import { UserNotFoundError } from "../errors/user.error.js";
+import { SessionNotFoundError, SessionFullError } from "../errors/session.error.js";
 
 export const findUserByEmail = async (email) => {
     try{
@@ -170,27 +171,79 @@ export const softDeleteUser = async (id) => {
 
 export const findRandomUserByPool = async (id) => {
   const poolRaw = await prisma.user.findFirst({
+    where: { id },
+    select: { pool: true },
+  });
+
+  const sessions = await prisma.matchingSession.findMany({
     where: {
-        id
+      status: "CHATING",
+      participants: { some: { userId: id } },
     },
     select: {
-        pool: true
-    }
-  })
+      participants: {
+        where: { userId: { not: id } },
+        select: { userId: true },
+      },
+    },
+  });
+
+  const sessionOtherUserIds = sessions.flatMap((s) =>
+    s.participants.map((p) => p.userId)
+  );
+
+  const friendIdsRaw = await prisma.friend.findMany({
+    where: { OR: [{ userAId: id }, { userBId: id }] },
+    select: { userAId: true, userBId: true },
+  });
+
+  const friendIds = friendIdsRaw
+    .map((r) => (r.userAId === id ? r.userBId : r.userAId))
+    .filter((x) => x != null);
+
+  const excludeIds = [...new Set([id, ...friendIds, ...sessionOtherUserIds])];
+
   const pool = poolRaw?.pool;
+
   const rows = await xprisma.user.findMany({
     where: {
-        blockerUserId: id,
-        pool,
-        id: { not: id }
+      blockerUserId: id,
+      pool,
+      id: { notIn: excludeIds },
     },
-    select: {
-        id: true
-    }
-  })
-  const length = rows.length;
-  const randomNum = Math.floor(Math.random() * length);
-  return rows[randomNum]?.id ?? null;
+    select: { id: true },
+  });
+
+  const candidateIds = rows.map((r) => r.id);
+  if (candidateIds.length === 0) return null;
+    
+  const counts = await prisma.sessionParticipant.groupBy({
+    by: ["userId"],
+    where: {
+      userId: { in: candidateIds },
+      session: { status: "CHATING" }, 
+    },
+    _count: { sessionId: true },
+  });
+
+  const countMap = new Map(counts.map((r) => [r.userId, r._count.sessionId]));
+
+  const availableIds = candidateIds.filter(
+    (uid) => (countMap.get(uid) ?? 0) <= 10
+  );
+
+  if (availableIds.length === 0) {
+    throw new SessionFullError();
+  }
+
+  const randomId = availableIds[Math.floor(Math.random() * availableIds.length)];
+
+  const pickedCount = countMap.get(randomId) ?? 0;
+  if (pickedCount > 10) {
+    throw new SessionNotFoundError(undefined, undefined, randomId);
+  }
+
+  return randomId;
 };
 
 

--- a/src/services/session.service.js
+++ b/src/services/session.service.js
@@ -52,7 +52,7 @@ export const createMatchingSession = async (
   const count = await countMatchingSessionByUserId(userId);
   console.log("count" + count);
   if(count >= 10) throw new SessionCountOverError(undefined, undefined, { count });
-  const question = await findQuestionByQuesionId(questionId);
+  const question = await findQuestionByQuestionId(questionId);
   console.log("question" + question.id);
   if(question == null) throw new QuestionNotFoundError(undefined, undefined, { questionId });
 

--- a/src/services/session.service.js
+++ b/src/services/session.service.js
@@ -136,8 +136,6 @@ export const createSessionReview = async (
     );
     if (!result) throw new SessionInternalError();
     return {
-      status: 200,
-      message: "세션에 대한 review가 작성되었습니다.",
       data: result,
     };
   } catch (error) {

--- a/src/services/session.service.js
+++ b/src/services/session.service.js
@@ -5,27 +5,28 @@ import {
   updateMatchingSessionToFriends,
   findSessionParticipantByUserIdAndSessionId,
   findMatchingSessionBySessionId,
+  countMatchingSessionByUserId
 } from "../repositories/session.repository.js";
 import {
+  SessionCountOverError,
   SessionInternalError,
   SessionParticipantNotFoundError,
+  UnExpectArgumentsError,
 } from "../errors/session.error.js";
 import { InvalidUserError } from "../errors/user.error.js";
 import { findUserById } from "../repositories/user.repository.js";
+import { findQuestionByQuesionId } from "../repositories/question.repository.js";
+import { QuestionNotFoundError } from "../errors/question.error.js";
+import { UnExpectedReportReasonError } from "../errors/report.error.js";
+import { BadRequestError, NotFoundError, InternalServerError } from "../errors/base.error.js";
 
-async function assertUsersExistOrThrow(userId, targetUserId) {
-  const [userById, targetUserById] = await Promise.all([
+async function assertUsersExistOrThrow(userId) {
+  const [userById] = await Promise.all([
     findUserById(userId),
-    findUserById(targetUserId),
   ]);
 
   if (!userById)
     throw new InvalidUserError(userId, "잘못된 유저 정보 입력입니다.");
-  if (!targetUserById)
-    throw new InvalidUserError(
-      targetUserId,
-      "잘못된 타겟 유저 정보 입력입니다."
-    );
 }
 
 export function validateTag(tag) {
@@ -46,44 +47,26 @@ export function validateTemperatureScore(temperatureScore) {
 
 export const createMatchingSession = async (
   userId,
-  targetUserId,
   questionId
 ) => {
-  //question 존재 유무 확인
+  const count = await countMatchingSessionByUserId(userId);
+  console.log("count" + count);
+  if(count >= 10) throw new SessionCountOverError(undefined, undefined, { count });
+  const question = await findQuestionByQuesionId(questionId);
+  console.log("question" + question.id);
+  if(question == null) throw new QuestionNotFoundError(undefined, undefined, { questionId });
+
   try {
-    const result = await acceptSessionRequestTx(userId, targetUserId, questionId);
-    if (!result) throw new SessionInternalError();
+    const result = await acceptSessionRequestTx(userId, questionId);
+    if (result == null) throw new SessionInternalError(undefined, undefined, { userId, questionId });
     return {
-      status: 200,
-      message: "question에 따른 세션이 생성되었습니다.",
       data: result,
     };
   } catch (error) {
-    // 2. Prisma에서 정의한 에러인지 확인
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      // 주요 에러 코드별 처리
-      switch (error.code) {
-        case "P2002":
-          throw new Error("이미 존재하는 데이터입니다. (중복 오류)");
-        case "P2025":
-          throw new Error("대상 데이터를 찾을 수 없습니다.");
-        case "P2003":
-          throw new Error("연결된 상위 데이터(질문 등)가 존재하지 않습니다.");
-        default:
-          throw new Error(
-            `데이터베이스 오류가 발생했습니다. (코드: ${error.code})`
-          );
-      }
+    if (error instanceof BadRequestError || error instanceof NotFoundError || error instanceof InternalServerError) {
+      throw error;
     }
-
-    // 3. Prisma 문법 오류 (필드명 오타 등)
-    if (error instanceof Prisma.PrismaClientValidationError) {
-      throw new Error("데이터 형식이 맞지 않거나 필수값이 누락되었습니다.");
-    }
-
-    // 4. 그 외 일반적인 에러 처리
-    console.error("Unexpected Error:", error);
-    throw new Error("알 수 없는 오류가 발생했습니다.");
+    throw new SessionInternalError();
   }
 };
 
@@ -93,40 +76,17 @@ export const updateSessionFriends = async (userId, sessionId) => {
       userId,
       sessionId
     );
-    if (findResult.length == 0) throw new SessionParticipantNotFoundError();
+    if (findResult.length == 0) throw new SessionParticipantNotFoundError(undefined, undefined, { sessionId });
     const result = await updateMatchingSessionToFriends(sessionId);
     if (!result) throw new SessionInternalError();
     return {
-      status: 200,
-      message: "세션 상태가 FRIENDS으로 변경되었습니다.",
       data: result,
     };
   } catch (error) {
-    // 2. Prisma에서 정의한 에러인지 확인
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      // 주요 에러 코드별 처리
-      switch (error.code) {
-        case "P2002":
-          throw new Error("이미 존재하는 데이터입니다. (중복 오류)");
-        case "P2025":
-          throw new Error("대상 데이터를 찾을 수 없습니다.");
-        case "P2003":
-          throw new Error("연결된 상위 데이터(질문 등)가 존재하지 않습니다.");
-        default:
-          throw new Error(
-            `데이터베이스 오류가 발생했습니다. (코드: ${error.code})`
-          );
-      }
+    if (error instanceof BadRequestError || error instanceof NotFoundError) {
+      throw error;
     }
-
-    // 3. Prisma 문법 오류 (필드명 오타 등)
-    if (error instanceof Prisma.PrismaClientValidationError) {
-      throw new Error("데이터 형식이 맞지 않거나 필수값이 누락되었습니다.");
-    }
-
-    // 4. 그 외 일반적인 에러 처리
-    console.error("Unexpected Error:", error);
-    throw new Error("알 수 없는 오류가 발생했습니다.");
+    throw new SessionInternalError();
   }
 };
 
@@ -136,40 +96,17 @@ export const updateSessionDiscarded = async (userId, sessionId) => {
       userId,
       sessionId
     );
-    if (findResult.length == 0) throw new SessionParticipantNotFoundError();
+    if (findResult.length == 0) throw new SessionParticipantNotFoundError(undefined, undefined, { sessionId });
     const result = await updateMatchingSessionToDiscard(sessionId);
     if (!result) throw new SessionInternalError();
     return {
-      status: 200,
-      message: "세션 상태가 DISCARDED로 변경되었습니다.",
       data: result,
     };
   } catch (error) {
-    // 2. Prisma에서 정의한 에러인지 확인
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      // 주요 에러 코드별 처리
-      switch (error.code) {
-        case "P2002":
-          throw new Error("이미 존재하는 데이터입니다. (중복 오류)");
-        case "P2025":
-          throw new Error("대상 데이터를 찾을 수 없습니다.");
-        case "P2003":
-          throw new Error("연결된 상위 데이터(질문 등)가 존재하지 않습니다.");
-        default:
-          throw new Error(
-            `데이터베이스 오류가 발생했습니다. (코드: ${error.code})`
-          );
-      }
+    if (error instanceof BadRequestError || error instanceof NotFoundError) {
+      throw error;
     }
-
-    // 3. Prisma 문법 오류 (필드명 오타 등)
-    if (error instanceof Prisma.PrismaClientValidationError) {
-      throw new Error("데이터 형식이 맞지 않거나 필수값이 누락되었습니다.");
-    }
-
-    // 4. 그 외 일반적인 에러 처리
-    console.error("Unexpected Error:", error);
-    throw new Error("알 수 없는 오류가 발생했습니다.");
+    throw new SessionInternalError();
   }
 };
 
@@ -180,20 +117,11 @@ export const createSessionReview = async (
   tag
 ) => {
   if (!validateTag(tag)) {
-    return res.status(400).json({
-      errorCode: "VALIDATION_400_TAG",
-      reason:
-        "tag는 그냥 그래요, 좋아요!, 또 만나고 싶어요 중 하나여야 합니다.",
-      data: { tag },
-    });
+    throw new UnExpectArgumentsError(undefined, undefined, { tag });
   }
 
   if (!validateTemperatureScore(temperatureScore)) {
-    return res.status(400).json({
-      errorCode: "VALIDATION_400_TEMPERATURE_SCORE",
-      reason: "temperatureScore는 0부터 100 사이의 숫자여야 합니다.",
-      data: { temperatureScore },
-    });
+    throw new UnExpectArgumentsError(undefined, undefined, { temperatureScore });
   }
   const targetUserId = await findSessionParticipantByUserIdAndSessionId(userId, id);
   assertUsersExistOrThrow(userId, targetUserId);
@@ -213,30 +141,9 @@ export const createSessionReview = async (
       data: result,
     };
   } catch (error) {
-    // 2. Prisma에서 정의한 에러인지 확인
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      // 주요 에러 코드별 처리
-      switch (error.code) {
-        case "P2002":
-          throw new Error("이미 존재하는 데이터입니다. (중복 오류)");
-        case "P2025":
-          throw new Error("대상 데이터를 찾을 수 없습니다.");
-        case "P2003":
-          throw new Error("연결된 상위 데이터(질문 등)가 존재하지 않습니다.");
-        default:
-          throw new Error(
-            `데이터베이스 오류가 발생했습니다. (코드: ${error.code})`
-          );
-      }
+    if (error instanceof BadRequestError || error instanceof NotFoundError) {
+      throw error;
     }
-
-    // 3. Prisma 문법 오류 (필드명 오타 등)
-    if (error instanceof Prisma.PrismaClientValidationError) {
-      throw new Error("데이터 형식이 맞지 않거나 필수값이 누락되었습니다.");
-    }
-
-    // 4. 그 외 일반적인 에러 처리
-    console.error("Unexpected Error:", error);
-    throw new Error("알 수 없는 오류가 발생했습니다.");
+    throw new SessionInternalError();
   }
 };

--- a/src/services/session.service.js
+++ b/src/services/session.service.js
@@ -15,7 +15,7 @@ import {
 } from "../errors/session.error.js";
 import { InvalidUserError } from "../errors/user.error.js";
 import { findUserById } from "../repositories/user.repository.js";
-import { findQuestionByQuesionId } from "../repositories/question.repository.js";
+import { findQuestionByQuestionId } from "../repositories/question.repository.js";
 import { QuestionNotFoundError } from "../errors/question.error.js";
 import { UnExpectedReportReasonError } from "../errors/report.error.js";
 import { BadRequestError, NotFoundError, InternalServerError } from "../errors/base.error.js";


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#108-feat-session-api-수정 -> dev
ex) feature/#3-로그인구현 -> develop

### 변경 사항
- session.error.js을 base.error.js 기반으로 동작되도록 수정
- session.repository.js의 acceptSessionRequestTx가 정상 동작되도록 수정
- session.service.js를 위의 수정 사항에 맞춰 수정
- session.repository.js에 updateMatchingSessionToChating 추가
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/3750280c-c379-4f8f-a58b-efc3d8a1837d" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/4397d389-ef6f-4416-81dc-f4d325eff265" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/bc57fe5e-9bb0-4331-b9f6-88c8fb999978" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/d225e049-b2ef-4907-ad7e-7e7923e351de" />

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
