### PR TITLE
Fix: 친구 신청 수락 시, 세션 상태 FRIENDS로 함께 변경 (#160)

### DIFF
--- a/src/controllers/friend.controller.js
+++ b/src/controllers/friend.controller.js
@@ -77,8 +77,8 @@ export const handleGetOutgoingFriendRequests = async (req, res, next) => {
 
 export const handleAcceptFriendRequest = async (req, res, next) => {
   // 친구 신청 수락 로직 구현
-  const receiverUserId = req.user.id;
-  const { requesterUserId } = req.params;
+  const receiverUserId = Number(36);
+  const requesterUserId = Number(req.params.requesterUserId);
   userIsNull(receiverUserId, requesterUserId);
   try {
     const result = await acceptFriendRequest(receiverUserId, requesterUserId);

--- a/src/controllers/friend.controller.js
+++ b/src/controllers/friend.controller.js
@@ -77,7 +77,7 @@ export const handleGetOutgoingFriendRequests = async (req, res, next) => {
 
 export const handleAcceptFriendRequest = async (req, res, next) => {
   // 친구 신청 수락 로직 구현
-  const receiverUserId = Number(36);
+  const receiverUserId = req.user.id;
   const requesterUserId = Number(req.params.requesterUserId);
   userIsNull(receiverUserId, requesterUserId);
   try {

--- a/src/repositories/session.repository.js
+++ b/src/repositories/session.repository.js
@@ -94,7 +94,7 @@ export const updateMatchingSessionToFriends = async (sessionId) => {
 };
 
 export const updateMatchingSessionToDiscard = async (sessionId) => {
-  return await prisma.matchingSession.updateMany({
+  return await prisma.matchingSession.update({
     where: {
       id: sessionId,
     },

--- a/src/repositories/session.repository.js
+++ b/src/repositories/session.repository.js
@@ -94,7 +94,7 @@ export const updateMatchingSessionToFriends = async (sessionId) => {
 };
 
 export const updateMatchingSessionToDiscard = async (sessionId) => {
-  return await prisma.matchingSession.update({
+  return await prisma.matchingSession.updateMany({
     where: {
       id: sessionId,
     },
@@ -168,6 +168,19 @@ export const findMatchingSessionBySessionId = async (sessionId) => {
       id: sessionId,
     },
   });
+};
+
+export const findMatchingSessionByParticipantUserId = async (userId, otherUserId) => {
+  const session = await prisma.matchingSession.findFirst({
+    where: {
+      participants: {
+        every: {
+          userId: { in: [userId, otherUserId] },
+        },
+      },
+    },
+  });
+  return session;
 };
 
 export const countMatchingSessionByUserId = async (userId) => {

--- a/src/services/friend.service.js
+++ b/src/services/friend.service.js
@@ -230,7 +230,6 @@ export const acceptFriendRequest = async (receiverUserId, requesterUserId) => {
 // 6) 친구 신청 거절
 export const rejectFriendRequest = async (requesterUserId, receiverUserId) => {
   await assertUsersExistOrThrow(requesterUserId, receiverUserId);
-    const session = await findMatchingSessionByParticipantUserId(receiverUserId, requesterUserId);
   try {
     const rejectedFriendRequest = await updateFriendRequestRejectTx(
       requesterUserId, receiverUserId

--- a/src/services/friend.service.js
+++ b/src/services/friend.service.js
@@ -25,6 +25,8 @@ import {
   ConflictError,
   InternalServerError,
 } from "../errors/base.error.js";
+import { findMatchingSessionByParticipantUserId, updateMatchingSessionToFriends, updateMatchingSessionToDiscard } from "../repositories/session.repository.js";
+import { SessionInternalError, SessionNotFoundError } from "../errors/session.error.js";
 
 async function userExistsOrThrow(userId) {
   const userById = await findUserById(userId);
@@ -42,12 +44,12 @@ async function assertUsersExistOrThrow(userId, targetUserId) {
 
   if (!userById)
     throw new InvalidUserError(undefined, "잘못된 유저 정보 입력입니다.", {
-      userId,
+      userId
     });
 
   if (!targetUserById)
     throw new InvalidUserError(undefined, "잘못된 유저 정보 입력입니다.", {
-      targetUserId,
+      targetUserId
     });
 }
 
@@ -178,10 +180,17 @@ export const getOutgoingFriendRequests = async (userId) => {
   }
 };
 
-// 5) 친구 신청 수락
+// 5) 친구 신청 수락 (receiverUserId: userId, requesterUserId: targetUserId)
 export const acceptFriendRequest = async (receiverUserId, requesterUserId) => {
   await assertUsersExistOrThrow(receiverUserId, requesterUserId);
-
+  const session = await findMatchingSessionByParticipantUserId(receiverUserId, requesterUserId);
+  if (!session) { 
+    throw new SessionNotFoundError(undefined, undefined, {receiverUserId, requesterUserId});
+  }
+  const friendsSession = await updateMatchingSessionToFriends(session.id);
+  if(friendsSession.status != "FRIENDS") {
+    throw new SessionInternalError(undefined, "세션 상태 변경에 실패했습니다.", {sessionId: session.id});
+  }
   const req = await userExistsFriendRequest(receiverUserId, requesterUserId);
   if (!req)
     throw new FriendRequestNotFoundError(undefined, undefined, {
@@ -221,7 +230,7 @@ export const acceptFriendRequest = async (receiverUserId, requesterUserId) => {
 // 6) 친구 신청 거절
 export const rejectFriendRequest = async (requesterUserId, receiverUserId) => {
   await assertUsersExistOrThrow(requesterUserId, receiverUserId);
-
+    const session = await findMatchingSessionByParticipantUserId(receiverUserId, requesterUserId);
   try {
     const rejectedFriendRequest = await updateFriendRequestRejectTx(
       requesterUserId, receiverUserId


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Fix/#160-세션상태와친구상태통합
ex) feature/#3-로그인구현 -> develop

### 변경 사항
- friends/requests/accept/:requesterUserId 로 친구 신청 수락 시, 해당 세션 상태를 동시에 FRIENDS로 변경
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
<img width="4800" height="1800" alt="image" src="https://github.com/user-attachments/assets/f2326edf-a261-4a24-b6ca-5ed12a2b0710" />

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
