### PR TITLE
Fix/ 세션생성로직변경 (#166)

### DIFF
--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -179,7 +179,7 @@ export const findRandomUserByPool = async (id) => {
 
   const sessions = await prisma.matchingSession.findMany({
     where: {
-      status: "CHATING",
+      status: { in: ["PENDING", "CHATING"] },
       participants: { some: { userId: id } },
     },
     select: {

--- a/src/services/session.service.js
+++ b/src/services/session.service.js
@@ -4,7 +4,8 @@ import {
   updateMatchingSessionToDiscard,
   updateMatchingSessionToFriends,
   findSessionParticipantByUserIdAndSessionId,
-  countMatchingSessionWhichChating
+  countMatchingSessionWhichChating,
+  findMatchingSessionByParticipantUserId
 } from "../repositories/session.repository.js";
 import {
   SessionCountOverError,
@@ -46,6 +47,10 @@ export function validateTemperatureScore(temperatureScore) {
 }
 
 export const createMatchingSession = async (userId, targetUserId, questionId, tx) => {
+  const existingSession = await findMatchingSessionByParticipantUserId(userId, targetUserId);
+  if (existingSession) {
+    throw new SessionInternalError('An active session already exists between these users.', undefined, { userId, targetUserId });
+  }
   try {
     const result = await acceptSessionRequestTx(userId, targetUserId, questionId, tx);
     if (result == null) throw new SessionInternalError(undefined, undefined, { userId, questionId });


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Fix/#166-세션생성로직변경 -> dev
ex) feature/#3-로그인구현 -> develop

### 변경 사항
- user.repository.js의 findRandomUserByPool에서 세션 검색 기준을 CHATING에서 CHATING과 PENDING으로 변경
- session.service.js의 createMatchingSession에서 두 유저 기준 session_participant를 검색하여 존재 시 에러 출력
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
