### PR TITLE
Fix: emotions의 결과값 수정 (#176)

### DIFF
--- a/src/repositories/weeklyReport.repository.js
+++ b/src/repositories/weeklyReport.repository.js
@@ -195,7 +195,7 @@ export const findWeeklyReportEmotionByRId = async(rId) => {
             ratio: true,
             count: true,
         },
-        orderBy: [{ count: "asc"}, {ratio: "desc"}]
+        orderBy: [{ count: "asc"}, { ratio: "desc" }]
     })
 }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Fix/#176-weeklyReport-결과값-반환-수정
ex) feature/#3-로그인구현 -> develop

### 변경 사항
- readWeeklyReport의 emotion index를 숫자에서 TOTAL, MON, TUE, WED, THU, FRI, SAT, SUN 로 변경
- emotions의 TOTAL의 4번째 이하 값들을 기타로 묶기, ratio 값은 더해서 하나로 묶음
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/db837aed-286e-4d97-94ee-8eddc9a96f72" />

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
