### PR TITLE
fix: weeklyReport가 없을 때 빈 값을 정상 반환하도록 수정 (#180)

### DIFF
--- a/src/services/weeklyReport.service.js
+++ b/src/services/weeklyReport.service.js
@@ -274,9 +274,8 @@ export const readWeeklyReport = async (userId) => {
   try {
     const weeklyReport = await findWeeklyReportByUserIdAndDate(userId);
     if (!weeklyReport) {
-      throw new WeeklyReportNotFoundError(undefined, undefined, userId);
+      return { data: {} };
     }
-
     const keywords = await findWeeklyReportKeywordByReportId(weeklyReport.id);
     const highlights = await findWeeklyReportHighlightByRId(weeklyReport.id);
     const emotionsRaw = await findWeeklyReportEmotionByRId(weeklyReport.id);
@@ -376,9 +375,6 @@ export const readWeeklyReport = async (userId) => {
       },
     };
   } catch (error) {
-    if (error?.code === "P2025") {
-      throw new WeeklyReportNotFoundError(undefined, undefined, userId);
-    }
     throw new WeeklyReportInternalError(undefined, undefined, {
       reason: error.message,
       action: "READ_WEEKLY_REPORT",


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#180-불필요한-에러처리-삭제 -> dev
ex) feature/#3-로그인구현 -> develop

### 변경 사항
- weeklyReport.service.js에서 findWeeklyReport의 결과가 없을 시 빈 data를 출력하도록 변경
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/423cdea9-b732-47a8-b784-be78a1f1ce0c" />

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
