### PR TITLE
Refactor: mailbox 서비스 레이어 DB 조회를 respository로 이동 및 questionTitle 반환 수정 (#163)

### DIFF
--- a/src/repositories/letter.repository.js
+++ b/src/repositories/letter.repository.js
@@ -468,3 +468,111 @@ export const selectQueuedLetter = async () => {
 
     return letter;
 }
+
+// 세션별 편지 개수 조회
+export const countLettersBySessionIdAndUserId = async ({ sessionId, userId, letterType }) => {
+  return await prisma.letter.count({
+    where: {
+      letterType,
+      sessionId: sessionId,
+      OR: [
+        { receiverUserId: userId },
+        { senderUserId: userId }
+      ]
+    }
+  });
+};
+
+// 세션별 읽지 않은 편지 개수 조회
+export const countUnreadLettersBySessionIdAndUserId = async ({ sessionId, userId, letterType }) => {
+  return await prisma.letter.count({
+    where: {
+      letterType,
+      sessionId: sessionId,
+      receiverUserId: userId,
+      readAt: null,
+    }
+  });
+};
+
+// 세션별 받은 편지 조회
+export const findReceivedLettersBySessionIdAndUserId = async ({ sessionId, userId, letterType }) => {
+  return await prisma.letter.findMany({
+    where: {
+      receiverUserId: userId,
+      sessionId: sessionId,
+      letterType,
+    },
+    orderBy: [{ deliveredAt: "desc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      title: true,
+      deliveredAt: true,
+      readAt: true,
+      createdAt: true,
+      question: {
+        select: {
+          content: true
+        }
+      },
+      design: {
+        select: {
+          paper: {
+            select: {
+              id: true,
+              color: true,
+            }
+          },
+          stamp: {
+            select: {
+              id: true,
+              name: true,
+              assetUrl: true
+            }
+          },
+        },
+      },
+    },
+  });
+};
+
+// 세션별 보낸 편지 조회
+export const findSentLettersBySessionIdAndUserId = async ({ sessionId, userId, letterType }) => {
+  return await prisma.letter.findMany({
+    where: {
+      senderUserId: userId,
+      sessionId: sessionId,
+      letterType,
+    },
+    orderBy: [{ deliveredAt: "desc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      title: true,
+      deliveredAt: true,
+      readAt: true,
+      createdAt: true,
+      question: {
+        select: {
+          content: true
+        }
+      },
+      design: {
+        select: {
+          paper: {
+            select: {
+              id: true,
+              color: true,
+            }
+          },
+          stamp: {
+            select: {
+              id: true,
+              name: true,
+              assetUrl: true
+            }
+          },
+        },
+      },
+    },
+  });
+};

--- a/src/repositories/session.repository.js
+++ b/src/repositories/session.repository.js
@@ -202,3 +202,24 @@ export const countMatchingSessionByUserId = async (userId) => {
 
   return count;
 };
+
+// 세션 ID와 사용자 ID로 세션 조회 (참가자 포함)
+export const findMatchingSessionBySessionIdAndUserId = async ({ sessionId, userId }) => {
+  return await prisma.matchingSession.findFirst({
+    where: {
+      id: sessionId,
+      participants: {
+        some: {
+          userId: userId
+        }
+      }
+    },
+    include: {
+      participants: {
+        select: {
+          userId: true
+        }
+      }
+    }
+  });
+};

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -591,6 +591,11 @@ export const findSelfLetters = async ({ userId, letterType }) => {
       createdAt: true,
       deliveredAt: true,
       questionId: true,
+      question: {
+        select: {
+          content: true
+        }
+      },
       design: {
         select: { 
           paperId: true,

--- a/src/swagger/mailbox.swagger.js
+++ b/src/swagger/mailbox.swagger.js
@@ -522,9 +522,10 @@
  *                                 type: string
  *                                 format: date-time
  *                                 nullable: true
- *                               questionId:
- *                                 type: integer
+ *                               questionTitle:
+ *                                 type: string
  *                                 nullable: true
+ *                                 description: 질문 내용
  *                               paperId:
  *                                 type: integer
  *                                 nullable: true


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

ex) feature/#163-questionTitle-반환-수정-및-mailbox리펙토링 -> develop

### 변경 사항
- mailbox 리펙토링
- questionTitle 반환 수정

### 테스트 결과
{
    "resultType": "SUCCESS",
    "error": null,
    "success": {
        "letters": [
            {
                "id": 49,
                "title": "나에게 쓰는 편지 제목 1",
                "createdAt": "2026-01-23T02:04:22.000Z",
                "questionTitle": "질문 내용...",
                "paperId": null,
                "stampId": null,
                "stampUrl": null
            }
        ]
    }
}
